### PR TITLE
Allow disabling server certificate verification on https protocol.

### DIFF
--- a/rundeck/connection.py
+++ b/rundeck/connection.py
@@ -114,6 +114,8 @@ class RundeckConnectionTolerant(object):
                 Rundeck user password (used in combo with usr)
             api_version : int
                 Rundeck API version
+            verify_cert : bool
+                Server certificate verification (HTTPS only)
         """
         self.protocol = protocol
         self.usr = usr = kwargs.get('usr', None)


### PR DESCRIPTION
If https protocol is used but server does not have a verified certificate, requests shall be fail with the following error -

requests.exceptions.SSLError: [Errno 1] _ssl.c:504: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed

To resolve this I add option to control the request verify argument and allow to disable certificate verification by using -

rd = Rundeck(server='localhost', protocol='https', port=4443, api_token="xxxx", verify_cert=False)
