### PR TITLE
fix encoding error on parsing response

### DIFF
--- a/rundeck/connection.py
+++ b/rundeck/connection.py
@@ -45,7 +45,7 @@ class RundeckResponse(object):
         self._as_dict_method = None
         self.response = response
         self.body = self.response.text
-        self.etree = ElementTree.fromstring(self.body)
+        self.etree = ElementTree.fromstring(self.body.encode('utf-8'))
 
     @memoize
     def pprint(self):


### PR DESCRIPTION
On python2, ``elementree.fromstring`` needs encoding manualy.

```
Python 2.7.9 (default, Mar  1 2015, 12:57:24)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from xml.etree import ElementTree as et
>>> et.fromstring(u'<a>あああ</a>')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1300, in XML
    parser.feed(text)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1640, in feed
    self._parser.Parse(data, 0)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 3-5: ordinal not in range(128)
>>> et.fromstring(u'<a>あああ</a>'.encode('utf-8'))
<Element 'a' at 0x7fca357be850>
```

while python3, ``elementtree.fromstring`` accepts both str and bytes.

```
Python 3.4.2 (default, Oct  8 2014, 10:45:20)
[GCC 4.9.1] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from xml.etree import ElementTree as et
>>> et.fromstring(u'<a>あああ</a>')
<Element 'a' at 0x7f365d47c688>
>>> et.fromstring(u'<a>あああ</a>'.encode('utf-8'))
<Element 'a' at 0x7f365cdb70e8>
```